### PR TITLE
Update ByProjectKeyInStoreKeyByStoreKeyCartsGet

### DIFF
--- a/commercetools.Sdk/commercetools.Sdk.Api/Generated/Client/RequestBuilders/InStore/ByProjectKeyInStoreKeyByStoreKeyCartsGet.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Api/Generated/Client/RequestBuilders/InStore/ByProjectKeyInStoreKeyByStoreKeyCartsGet.cs
@@ -103,10 +103,10 @@ namespace commercetools.Api.Client.RequestBuilders.InStore
             return this.AddQueryParam($"var.{varName}", predicateVar);
         }
 
-        public async Task<Object> ExecuteAsync()
+        public async Task<commercetools.Api.Models.Carts.ICartPagedQueryResponse> ExecuteAsync()
         {
             var requestMessage = Build();
-            return await ApiHttpClient.ExecuteAsync<Object>(requestMessage);
+            return await ApiHttpClient.ExecuteAsync<commercetools.Api.Models.Carts.ICartPagedQueryResponse>(requestMessage);
         }
 
     }


### PR DESCRIPTION
Updated `ByProjectKeyInStoreKeyByStoreKeyCartsGet.cs` to ensure the `ExecuteAsync()` returned a `ICartPagedQueryResponse` rather than just an `object`.

Currently, this code cannot be used as by just returning an object you cannot work with it. You cannot deserialize it or anything, so I believe it should be returning an `ICartPagedQueryResponse` like similar classes.