### PR TITLE
fix: serialize OrderSearchRequest's Query as object

### DIFF
--- a/commercetools.Sdk/commercetools.Sdk.Api/Generated/Models/Orders/IOrderSearchRequest.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Api/Generated/Models/Orders/IOrderSearchRequest.cs
@@ -6,7 +6,7 @@ namespace commercetools.Api.Models.Orders
     [DeserializeAs(typeof(commercetools.Api.Models.Orders.OrderSearchRequest))]
     public partial interface IOrderSearchRequest
     {
-        string Query { get; set; }
+        object Query { get; set; }
 
         string Sort { get; set; }
 

--- a/commercetools.Sdk/commercetools.Sdk.Api/Generated/Models/Orders/OrderSearchRequest.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Api/Generated/Models/Orders/OrderSearchRequest.cs
@@ -2,7 +2,7 @@ namespace commercetools.Api.Models.Orders
 {
     public partial class OrderSearchRequest : IOrderSearchRequest
     {
-        public string Query { get; set; }
+        public object Query { get; set; }
 
         public string Sort { get; set; }
 


### PR DESCRIPTION
This is my attempt to fix [the issue 138](https://github.com/commercetools/commercetools-dotnet-core-sdk-v2/issues/138) by making `Query` to `object` type