### PR TITLE
chore(docs): update naming to match new branding initiative

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -10,7 +10,7 @@ The SDK [V2](/) has some features which is not exists in [V1](https://github.com
 ## Comparison of SDK Installation
 | Package                | V2                                                     | V1                                              |
 |------------------------|--------------------------------------------------------|-------------------------------------------------|
-| Composable Commerce    | ```dotnet add package commercetools.Sdk.Api```         | ```dotnet add package commercetools.Sdk.All```  |
+| HTTP API   | ```dotnet add package commercetools.Sdk.Api```         | ```dotnet add package commercetools.Sdk.All```  |
 | Import API             | ```dotnet add package commercetools.Sdk.ImportApi```   |                                                 |
 | ML API                 | ```dotnet add package commercetools.Sdk.MLApi```       |                                                 |
 | History API            | ```dotnet add package commercetools.Sdk.HistoryApi```  |                                                 |

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,32 +1,32 @@
 # Comparison between DotNet Core SDK V2 and V1
 ## Why I should use V2 SDK
 The SDK [V2](/) has some features which is not exists in [V1](https://github.com/commercetools/commercetools-dotnet-core-sdk) like:
-* V1 supports only the platform Api, but V2 has different packages to support things like platform, Import Api,Machine learning Api and History Api.
-* V2 SDK supports Me endpoints.
+* V1 supports only the Composable Commerce Api, but V2 has different packages to support things like Composable Commerce, Import API, Machine Learning API and History API.
+* V2 SDK supports ME endpoints.
 * V2 SDK is auto generated from RAML files like other SDKS which means less maintainability and it will be always up-to-date with backend new features.
 * V2 SDK is faster than V1 SDK as it’s using System.Text.Json in Serialization and Deserialisation
 * In SDK V1, you only have to configure clients and inject them in the service container in the App Start, but SDK V2, you can use the injected clients or use the ClientFactory to create clients on the fly.
 
 ## Comparison of SDK Installation
-| Package     | V2                                                     | V1                                              |
-|-------------|--------------------------------------------------------|-------------------------------------------------|
-| Platform    | ```dotnet add package commercetools.Sdk.Api```         | ```dotnet add package commercetools.Sdk.All```  |
-| Import Api  | ```dotnet add package commercetools.Sdk.ImportApi```   |                                                 |
-| ML Api      | ```dotnet add package commercetools.Sdk.MLApi```       |                                                 |
-| History Api | ```dotnet add package commercetools.Sdk.HistoryApi```  |                                                 |
+| Package                | V2                                                     | V1                                              |
+|------------------------|--------------------------------------------------------|-------------------------------------------------|
+| Composable Commerce    | ```dotnet add package commercetools.Sdk.Api```         | ```dotnet add package commercetools.Sdk.All```  |
+| Import API             | ```dotnet add package commercetools.Sdk.ImportApi```   |                                                 |
+| ML API                 | ```dotnet add package commercetools.Sdk.MLApi```       |                                                 |
+| History API            | ```dotnet add package commercetools.Sdk.HistoryApi```  |                                                 |
 
 ## Comparison of SDK Services Configuration
 After packages installation, you have to configure services using Dependency Injection Setup in the application Startup.cs
 
-| Package     | V2                                                                              | V1                                    |
-|-------------|---------------------------------------------------------------------------------|---------------------------------------|
-| Platform    | ```services.UseCommercetoolsApi(this.configuration, "Client");```               | ```services.UseCommercetools(```
-|             |                                                                                 |  ```this.configuration,"Client");```  |
-| Import Api  | ```services.UseCommercetoolsImportApi(this.configuration, "ImportClient");```   |                                       |
-| ML Api      | ```services.UseCommercetoolsMLApi(this.configuration, "MLClient");```           |                                       |
-| History Api | ```services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");``` |                                       |
+| Package                | V2                                                                              | V1                                    |
+|------------------------|---------------------------------------------------------------------------------|---------------------------------------|
+| Composable Commerce    | ```services.UseCommercetoolsApi(this.configuration, "Client");```               | ```services.UseCommercetools(```
+|                        |                                                                                 |  ```this.configuration,"Client");```  |
+| Import API             | ```services.UseCommercetoolsImportApi(this.configuration, "ImportClient");```   |                                       |
+| ML API                 | ```services.UseCommercetoolsMLApi(this.configuration, "MLClient");```           |                                       |
+| History API            | ```services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");``` |                                       |
 
-## Comparison of how to make requests to the platform
+## Comparison of how to make requests to Composable Commerce
 ```c#
     // Create CategoryDraft
     var categoryDraft = new CategoryDraft

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -23,7 +23,7 @@ After packages installation, you have to configure services using Dependency Inj
 | HTTP API    | ```services.UseCommercetoolsApi(this.configuration, "Client");```               | ```services.UseCommercetools(```
 |                        |                                                                                 |  ```this.configuration,"Client");```  |
 | Import API             | ```services.UseCommercetoolsImportApi(this.configuration, "ImportClient");```   |                                       |
-| ML API                 | ```services.UseCommercetoolsMLApi(this.configuration, "MLClient");```           |                                       |
+| Machine Learning API                 | ```services.UseCommercetoolsMLApi(this.configuration, "MLClient");```           |                                       |
 | Change History API            | ```services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");``` |                                       |
 
 ## Comparison of how to make requests to the Composable Commerce HTTP API

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,7 +1,7 @@
 # Comparison between DotNet Core SDK V2 and V1
 ## Why I should use V2 SDK
 The SDK [V2](/) has some features which is not exists in [V1](https://github.com/commercetools/commercetools-dotnet-core-sdk) like:
-* V1 supports only the Composable Commerce Api, but V2 has different packages to support things like Composable Commerce, Import API, Machine Learning API and History API.
+* V1 only supports the Composable Commerce HTTP API, but V2 has different packages to support the Import API, Machine Learning API, and the Change History API.
 * V2 SDK supports ME endpoints.
 * V2 SDK is auto generated from RAML files like other SDKS which means less maintainability and it will be always up-to-date with backend new features.
 * V2 SDK is faster than V1 SDK as it’s using System.Text.Json in Serialization and Deserialisation

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -12,7 +12,7 @@ The SDK [V2](/) has some features which is not exists in [V1](https://github.com
 |------------------------|--------------------------------------------------------|-------------------------------------------------|
 | HTTP API   | ```dotnet add package commercetools.Sdk.Api```         | ```dotnet add package commercetools.Sdk.All```  |
 | Import API             | ```dotnet add package commercetools.Sdk.ImportApi```   |                                                 |
-| ML API                 | ```dotnet add package commercetools.Sdk.MLApi```       |                                                 |
+| Machine Learning API                 | ```dotnet add package commercetools.Sdk.MLApi```       |                                                 |
 | Change History API            | ```dotnet add package commercetools.Sdk.HistoryApi```  |                                                 |
 
 ## Comparison of SDK Services Configuration

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -24,7 +24,7 @@ After packages installation, you have to configure services using Dependency Inj
 |                        |                                                                                 |  ```this.configuration,"Client");```  |
 | Import API             | ```services.UseCommercetoolsImportApi(this.configuration, "ImportClient");```   |                                       |
 | ML API                 | ```services.UseCommercetoolsMLApi(this.configuration, "MLClient");```           |                                       |
-| History API            | ```services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");``` |                                       |
+| Change History API            | ```services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");``` |                                       |
 
 ## Comparison of how to make requests to Composable Commerce
 ```c#

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -13,7 +13,7 @@ The SDK [V2](/) has some features which is not exists in [V1](https://github.com
 | HTTP API   | ```dotnet add package commercetools.Sdk.Api```         | ```dotnet add package commercetools.Sdk.All```  |
 | Import API             | ```dotnet add package commercetools.Sdk.ImportApi```   |                                                 |
 | ML API                 | ```dotnet add package commercetools.Sdk.MLApi```       |                                                 |
-| History API            | ```dotnet add package commercetools.Sdk.HistoryApi```  |                                                 |
+| Change History API            | ```dotnet add package commercetools.Sdk.HistoryApi```  |                                                 |
 
 ## Comparison of SDK Services Configuration
 After packages installation, you have to configure services using Dependency Injection Setup in the application Startup.cs

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -20,7 +20,7 @@ After packages installation, you have to configure services using Dependency Inj
 
 | Package                | V2                                                                              | V1                                    |
 |------------------------|---------------------------------------------------------------------------------|---------------------------------------|
-| Composable Commerce    | ```services.UseCommercetoolsApi(this.configuration, "Client");```               | ```services.UseCommercetools(```
+| HTTP API    | ```services.UseCommercetoolsApi(this.configuration, "Client");```               | ```services.UseCommercetools(```
 |                        |                                                                                 |  ```this.configuration,"Client");```  |
 | Import API             | ```services.UseCommercetoolsImportApi(this.configuration, "ImportClient");```   |                                       |
 | ML API                 | ```services.UseCommercetoolsMLApi(this.configuration, "MLClient");```           |                                       |

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -26,7 +26,7 @@ After packages installation, you have to configure services using Dependency Inj
 | ML API                 | ```services.UseCommercetoolsMLApi(this.configuration, "MLClient");```           |                                       |
 | Change History API            | ```services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");``` |                                       |
 
-## Comparison of how to make requests to Composable Commerce
+## Comparison of how to make requests to the Composable Commerce HTTP API
 ```c#
     // Create CategoryDraft
     var categoryDraft = new CategoryDraft

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ var root2 = ImportApiFactory.Create(client);
 var root1 = client.WithMLApi();
 var root2 = MLApiFactory.Create(client);
 ```
-* `History API`:
+* `Change History API`:
 ```c#
 var root1 = client.WithHistoryApi();
 var root2 = HistoryApiFactory.Create(client);

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains the .NET SDKs generated from the Composable Commerce AP
 | Change History API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.HistoryApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)|
 
 ## Example and Training material
-Feel free to explore these examples using this SDK for calling Composable Commerce, and Import API.
+Feel free to explore these examples using this SDK for calling the Composable Commerce HTTP API, and Import API.
 [.NET Core SDK Training for V2 SDK](https://github.com/commercetools/commercetools-dotnet-sdk-training/tree/Training-SDKV2)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The client configuration needs to be added to appsettings.json in order for the 
 
 ##### Getting instance of ApiRoot
 you can use the instance inside the injected client or use ApiFactory to create a new instance.
-* `Composable Commerce API`:
+* `Composable Commerce HTTP API`:
 ```c#
 var root1 = client.WithApi();
 var root2 = ApiFactory.Create(client);

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The SDK consists of the following projects:
 * `commercetools.SDK.Api`: Contains all generated models and request builders to communicate with [Composable Commerce HTTP API](https://docs.commercetools.com/http-api.html).
 * `commercetools.SDK.ImportApi`: Contains all generated models and request builders to communicate with the [Import API](https://docs.commercetools.com/import-api/).
 * `commercetools.SDK.MLApi`: Contains all generated models and request builders to communicate with the [Machine Learning API](https://docs.commercetools.com/api/ml).
-* `commercetools.SDK.HistoryApi`: Contains all generated models and request builders to communicate with the history api.
+* `commercetools.SDK.HistoryApi`: Contains all generated models and request builders to communicate with the [Change History API](https://docs.commercetools.com/api/history/change-history).
 
 In addition, the SDK has the following directories:
 * `/IntegrationTests`: Integration tests for the SDK. A good way for anyone using the .NET SDK to understand it further.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ services.UseCommercetoolsApi(this.configuration, "Client"); // replace with your
 ```c#
 services.UseCommercetoolsImportApi(this.configuration, "ImportClient");
 ```
-* `ML API`:
+* `Machine Learning API`:
 ```c#
 services.UseCommercetoolsMLApi(this.configuration, "MLClient");
 ```

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ public async Task ExecuteAsync()
             .ExecuteAsync();
 }
 ```
-If you are going to create the client using the ClientFactory, Don't forget to call
+If you are going to create the client using the ClientFactory, don't forget to call
 SetupClient extension method [here](https://github.com/commercetools/commercetools-dotnet-core-sdk-v2/blob/master/commercetools.Sdk/commercetools.Base.Client/DependencyInjectionSetup.cs#L92) while building
 the services container to attach the Default Handlers like ErrorHandler and LoggerHandler to the Client like below:
 ```c#

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The SDK consists of the following projects:
 * `commercetools.Base.Serialization`: Serialization and deserialization services for responses and requests to the HTTP API using System.Text.Json.
 * `commercetools.SDK.Api`: Contains all generated models and request builders to communicate with [Composable Commerce HTTP API](https://docs.commercetools.com/http-api.html).
 * `commercetools.SDK.ImportApi`: Contains all generated models and request builders to communicate with the [Import API](https://docs.commercetools.com/import-api/).
-* `commercetools.SDK.MLApi`: Contains all generated models and request builders to communicate with the ml api.
+* `commercetools.SDK.MLApi`: Contains all generated models and request builders to communicate with the [Machine Learning API](https://docs.commercetools.com/api/ml).
 * `commercetools.SDK.HistoryApi`: Contains all generated models and request builders to communicate with the history api.
 
 In addition, the SDK has the following directories:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This repository contains the commercetools Composable Commerce, import-api and ml-api C# sdks generated from our api reference.
+This repository contains the .NET SDKs generated from the Composable Commerce API reference. 
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ var root2 = ApiFactory.Create(client);
 var root1 = client.WithImportApi();
 var root2 = ImportApiFactory.Create(client);
 ```
-* `ML API`:
+* `Machine Learning API`:
 ```c#
 var root1 = client.WithMLApi();
 var root2 = MLApiFactory.Create(client);

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ public async Task ExecuteAsync()
 ```
 If you are going to create the client using the ClientFactory, don't forget to call
 SetupClient extension method [here](https://github.com/commercetools/commercetools-dotnet-core-sdk-v2/blob/master/commercetools.Sdk/commercetools.Base.Client/DependencyInjectionSetup.cs#L92) while building
-the services container to attach the Default Handlers like ErrorHandler and LoggerHandler to the Client like below:
+the services container. This will attach the Default Handlers like ErrorHandler and LoggerHandler to the Client like below:
 ```c#
 services.SetupClient(
                 "MeClient",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the .NET SDKs generated from the Composable Commerce AP
 
 | Package | Version|
 | --------| --------------------------------------------------------------------------------------------------------- |
-| Composable Commerce API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.Api?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.Api)|
+| HTTP API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.Api?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.Api)|
 | Import API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.ImportApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)|
 | ML API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.MLApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.MLApi)|
 | History API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.HistoryApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)|

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The SDK consists of the following projects:
 * `commercetools.Base.Registration`: Helper classes for things like types retriever.
 * `commercetools.Base.Serialization`: Serialization and deserialization services for responses and requests to the HTTP API using System.Text.Json.
 * `commercetools.SDK.Api`: Contains all generated models and request builders to communicate with [Composable Commerce HTTP API](https://docs.commercetools.com/http-api.html).
-* `commercetools.SDK.ImportApi`: Contains all generated models and request builders to communicate with the [import api](https://docs.commercetools.com/import-api/).
+* `commercetools.SDK.ImportApi`: Contains all generated models and request builders to communicate with the [Import API](https://docs.commercetools.com/import-api/).
 * `commercetools.SDK.MLApi`: Contains all generated models and request builders to communicate with the ml api.
 * `commercetools.SDK.HistoryApi`: Contains all generated models and request builders to communicate with the history api.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the .NET SDKs generated from the Composable Commerce AP
 | --------| --------------------------------------------------------------------------------------------------------- |
 | HTTP API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.Api?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.Api)|
 | Import API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.ImportApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)|
-| ML API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.MLApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.MLApi)|
+| Machine Learning API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.MLApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.MLApi)|
 | Change History API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.HistoryApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)|
 
 ## Example and Training material

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The SDK consists of the following projects:
 * `commercetools.Base.Client`: Contains CtpClient which communicate with Composable Commerce to execute requests, it contains also the classes related to the client like tokens,middlewares and handlers.
 * `commercetools.Base.Registration`: Helper classes for things like types retriever.
 * `commercetools.Base.Serialization`: Serialization and deserialization services for responses and requests to the HTTP API using System.Text.Json.
-* `commercetools.SDK.Api`: Contains all generated models and request builders to communicate with [Composable Commerce API](https://docs.commercetools.com/http-api.html).
+* `commercetools.SDK.Api`: Contains all generated models and request builders to communicate with [Composable Commerce HTTP API](https://docs.commercetools.com/http-api.html).
 * `commercetools.SDK.ImportApi`: Contains all generated models and request builders to communicate with the [import api](https://docs.commercetools.com/import-api/).
 * `commercetools.SDK.MLApi`: Contains all generated models and request builders to communicate with the ml api.
 * `commercetools.SDK.HistoryApi`: Contains all generated models and request builders to communicate with the history api.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Feel free to explore these examples using this SDK for calling Composable Commer
 | [HTTP API](https://www.nuget.org/packages/commercetools.Sdk.Api) | ```dotnet add package commercetools.Sdk.Api```            |
 | [Import API](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)        | ```dotnet add package commercetools.Sdk.ImportApi```      |
 | [ML API](https://www.nuget.org/packages/commercetools.Sdk.MLApi)                | ```dotnet add package commercetools.Sdk.MLApi```          |
-| [History API](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)      | ```dotnet add package commercetools.Sdk.HistoryApi```     |
+| [Change History API](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)      | ```dotnet add package commercetools.Sdk.HistoryApi```     |
 
 ## Technical Overview
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ services.UseCommercetoolsImportApi(this.configuration, "ImportClient");
 ```c#
 services.UseCommercetoolsMLApi(this.configuration, "MLClient");
 ```
-* `History API`:
+* `Change History API`:
 ```c#
 services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ At a high level, to make a basic call to the API, do the following:
 
  In the ConfigureServices method of Startup.cs add the following:
 
-* `Composable Commerce API`:
+* `Composable Commerce HTTP API`:
 ```c#
 services.UseCommercetoolsApi(this.configuration, "Client"); // replace with your instance of IConfiguration
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Feel free to explore these examples using this SDK for calling Composable Commer
 | ------------------------------------------------------------------------------- | ----------------------------------------------------------|
 | [HTTP API](https://www.nuget.org/packages/commercetools.Sdk.Api) | ```dotnet add package commercetools.Sdk.Api```            |
 | [Import API](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)        | ```dotnet add package commercetools.Sdk.ImportApi```      |
-| [ML API](https://www.nuget.org/packages/commercetools.Sdk.MLApi)                | ```dotnet add package commercetools.Sdk.MLApi```          |
+| [Machine Learning API](https://www.nuget.org/packages/commercetools.Sdk.MLApi)                | ```dotnet add package commercetools.Sdk.MLApi```          |
 | [Change History API](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)      | ```dotnet add package commercetools.Sdk.HistoryApi```     |
 
 ## Technical Overview

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Feel free to explore these examples using this SDK for calling Composable Commer
 #### Download from [Nuget](https://www.nuget.org/profiles/commercetools)
 | Package                                                                         | Installation                                                                                                                                  |
 | ------------------------------------------------------------------------------- | ----------------------------------------------------------|
-| [Composable Commerce API](https://www.nuget.org/packages/commercetools.Sdk.Api) | ```dotnet add package commercetools.Sdk.Api```            |
+| [HTTP API](https://www.nuget.org/packages/commercetools.Sdk.Api) | ```dotnet add package commercetools.Sdk.Api```            |
 | [Import API](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)        | ```dotnet add package commercetools.Sdk.ImportApi```      |
 | [ML API](https://www.nuget.org/packages/commercetools.Sdk.MLApi)                | ```dotnet add package commercetools.Sdk.MLApi```          |
 | [History API](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)      | ```dotnet add package commercetools.Sdk.HistoryApi```     |

--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
-# commercetools .NET SDK
+# Composable Commerce .NET SDK
 
 ## Introduction
 
-This repository contains the commercetools platform, import-api and ml-api C# sdks generated from our api reference.
+This repository contains the commercetools Composable Commerce, import-api and ml-api C# sdks generated from our api reference.
 
 ## Packages
 
 | Package | Version|
 | --------| --------------------------------------------------------------------------------------------------------- |
-| Platform Api | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.Api?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.Api)|
-| Import Api | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.ImportApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)|
-| ML Api | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.MLApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.MLApi)|
-| History Api | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.HistoryApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)| 
+| Composable Commerce API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.Api?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.Api)|
+| Import API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.ImportApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)|
+| ML API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.MLApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.MLApi)|
+| History API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.HistoryApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)|
 
 ## Example and Training material
-Feel free to explore these examples using this SDK for calling Platform, and Import API.
+Feel free to explore these examples using this SDK for calling Composable Commerce, and Import API.
 [.NET Core SDK Training for V2 SDK](https://github.com/commercetools/commercetools-dotnet-sdk-training/tree/Training-SDKV2)
 
 ## Installation
 #### Download from [Nuget](https://www.nuget.org/profiles/commercetools)
-| Package                                                            | Installation                                                                                                   |
-| ------------------------------------------------------------------ | ----------------------------------------------------------|
-| [Platform Api](https://www.nuget.org/packages/commercetools.Sdk.Api) | ```dotnet add package commercetools.Sdk.Api```|
-| [Import Api](https://www.nuget.org/packages/commercetools.Sdk.ImportApi) | ```dotnet add package commercetools.Sdk.ImportApi```|
-| [ML Api](https://www.nuget.org/packages/commercetools.Sdk.MLApi) | ```dotnet add package commercetools.Sdk.MLApi```|
-| [History Api](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi) | ```dotnet add package commercetools.Sdk.HistoryApi```|
+| Package                                                                         | Installation                                                                                                                                  |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------|
+| [Composable Commerce API](https://www.nuget.org/packages/commercetools.Sdk.Api) | ```dotnet add package commercetools.Sdk.Api```            |
+| [Import API](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)        | ```dotnet add package commercetools.Sdk.ImportApi```      |
+| [ML API](https://www.nuget.org/packages/commercetools.Sdk.MLApi)                | ```dotnet add package commercetools.Sdk.MLApi```          |
+| [History API](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)      | ```dotnet add package commercetools.Sdk.HistoryApi```     |
 
 ## Technical Overview
 
 The SDK consists of the following projects:
 * `commercetools.Base.Abstractions`: Contains common classes and interfaces that can be used in other SDK projects like IClient and ISerializerService.
-* `commercetools.Base.Client`: Contains CtpClient which communicate with the platform to execute requests, it contains also the classes related to the client like tokens,middlewares and handlers.
+* `commercetools.Base.Client`: Contains CtpClient which communicate with Composable Commerce to execute requests, it contains also the classes related to the client like tokens,middlewares and handlers.
 * `commercetools.Base.Registration`: Helper classes for things like types retriever.
 * `commercetools.Base.Serialization`: Serialization and deserialization services for responses and requests to the HTTP API using System.Text.Json.
-* `commercetools.SDK.Api`: Contains all generated models and request builders to communicate with the [platform api](https://docs.commercetools.com/http-api.html).
+* `commercetools.SDK.Api`: Contains all generated models and request builders to communicate with [Composable Commerce API](https://docs.commercetools.com/http-api.html).
 * `commercetools.SDK.ImportApi`: Contains all generated models and request builders to communicate with the [import api](https://docs.commercetools.com/import-api/).
 * `commercetools.SDK.MLApi`: Contains all generated models and request builders to communicate with the ml api.
 * `commercetools.SDK.HistoryApi`: Contains all generated models and request builders to communicate with the history api.
@@ -52,7 +52,7 @@ In addition, the SDK has the following directories:
 ## Getting Started with the .NET SDK
 
 All operations (get, query, create, update, delete and others) are available in the generated request builders, so you can build the request and use the client to execute it and all the request builders accessible through ApiRoot.
-In order to use the client object, it needs to be setup first through dependency injection setup. 
+In order to use the client object, it needs to be setup first through dependency injection setup.
 
 ### Basic Workflow
 
@@ -69,19 +69,19 @@ At a high level, to make a basic call to the API, do the following:
 
  In the ConfigureServices method of Startup.cs add the following:
 
-* `Platform Api`:
+* `Composable Commerce API`:
 ```c#
 services.UseCommercetoolsApi(this.configuration, "Client"); // replace with your instance of IConfiguration
 ```
-* `Import Api`:
+* `Import API`:
 ```c#
 services.UseCommercetoolsImportApi(this.configuration, "ImportClient");
 ```
-* `ML Api`:
+* `ML API`:
 ```c#
 services.UseCommercetoolsMLApi(this.configuration, "MLClient");
 ```
-* `History Api`:
+* `History API`:
 ```c#
 services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");
 ```
@@ -104,33 +104,33 @@ The client configuration needs to be added to appsettings.json in order for the 
 
 ##### Getting instance of ApiRoot
 you can use the instance inside the injected client or use ApiFactory to create a new instance.
-* `Platform Api`:
+* `Composable Commerce API`:
 ```c#
 var root1 = client.WithApi();
 var root2 = ApiFactory.Create(client);
 ```
-* `Import Api`:
+* `Import API`:
 ```c#
 var root1 = client.WithImportApi();
 var root2 = ImportApiFactory.Create(client);
 ```
-* `ML Api`:
+* `ML API`:
 ```c#
 var root1 = client.WithMLApi();
 var root2 = MLApiFactory.Create(client);
 ```
-* `History Api`:
+* `History API`:
 ```c#
 var root1 = client.WithHistoryApi();
 var root2 = HistoryApiFactory.Create(client);
-``` 
+```
 
 ### Multiple Clients
-It is possible to use more than one client in the same application with different token providers. 
+It is possible to use more than one client in the same application with different token providers.
 The following code can be used to set it up 2 clients with the default ClientCredentials token provider:
 
 ```c#
-services.UseCommercetoolsApi(configuration, 
+services.UseCommercetoolsApi(configuration,
                 new List<string>{"AdminClient", "StoreClient"},
                 CreateTokenProvider);
 
@@ -149,7 +149,7 @@ The clients can then be injected by using IEnumerable and specific client can be
     {
         var storeClient = clients.FirstOrDefault(c => c.Name.Equals("StoreClient"));
     }
-``` 
+```
 
 ### Using SDK
 
@@ -161,7 +161,7 @@ public CategoryController(IClient client)
 {
     this.client = client;
 }
-public async Task CreatingRequests() 
+public async Task CreatingRequests()
 {
     // Create CategoryDraft
     var categoryDraft = new CategoryDraft
@@ -170,34 +170,34 @@ public async Task CreatingRequests()
                     Slug = new LocalizedString {{"en", "Slug"}},
                     Key = "Key"
                 };
-    
+
     // Use in the previous step configured client instance to send and receive a newly created Category
      var category = await client.WithApi().WithProjectKey("project-key")
                                     .Categories()
                                     .Post(categoryDraft)
                                     .ExecuteAsync();
-    
+
     // Get Category by id
     var queriedCategory = await client.WithApi().WithProjectKey("project-key")
                 .Categories()
                 .WithId(category.Id)
                 .Get()
                 .ExecuteAsync();
-                
+
     // Get Category by key
     var queriedCategory = await client.WithApi().WithProjectKey("project-key")
                 .Categories()
                 .WithKey(category.Key)
                 .Get()
                 .ExecuteAsync();
-    
+
     // Query Categories
     var response = await client.WithApi().WithProjectKey("project-key")
             .Categories()
             .Get()
             .WithWhere($"key = \"{category.Key}\"")
             .ExecuteAsync();
-    
+
     // Delete Category by id
     var deletedCategory = await client.WithApi().WithProjectKey("project-key")
             .Categories()
@@ -205,7 +205,7 @@ public async Task CreatingRequests()
             .Delete()
             .WithVersion(category.version)
             .ExecuteAsync();
-    
+
     // Update Category
     var newName = "newName";
     var action = new CategoryChangeNameAction
@@ -217,30 +217,30 @@ public async Task CreatingRequests()
                         Version = category.Version,
                         Actions = new List<ICategoryUpdateAction> {action}
                     };
-    
+
     var updatedCategory = await client.WithApi().WithProjectKey("project-key")
             .Categories()
             .WithId(category.Id)
             .Post(categoryUpdate)
             .ExecuteAsync();
-    
+
     // Delete Category by key
     var deletedCategory = await client.WithApi().WithProjectKey("project-key")
             .Categories()
             .WithKey(category.Key)
             .Delete()
             .WithVersion(category.Version)
-            .ExecuteAsync();        
+            .ExecuteAsync();
     }
-                
+
 ```
 ### Creating a client using ClientFactory
-You can get a client from injected services or you can create client on the fly using ClientFactory, 
+You can get a client from injected services or you can create client on the fly using ClientFactory,
 the example below illustrate how to create a client with password TokenFlow to get customer's orders:
 
 ```c#
 private readonly IServiceProvider serviceProvider;
-        
+
 public CustomerController(IServiceProvider serviceProvider)
 {
     this.serviceProvider = serviceProvider;
@@ -249,19 +249,19 @@ public async Task ExecuteAsync()
 {
     var email = "customerEmail";
     var password = "customerPassword";
-    
+
     var configuration = serviceProvider.GetService<IConfiguration>();
     var httpClientFactory = serviceProvider.GetService<IHttpClientFactory>();
     var serializerService = serviceProvider.GetService<SerializerService>();
-    
+
     var clientConfiguration = configuration.GetSection("MeClient").Get<ClientConfiguration>();
-    
+
     //Create passwordFlow TokenProvider
     var passwordTokenProvider = TokenProviderFactory
         .CreatePasswordTokenProvider(clientConfiguration,
             httpClientFactory,
             new InMemoryUserCredentialsStoreManager(email, password));
-    
+
     //Create MeClient
     var meClient = ClientFactory.Create(
         "MeClient",
@@ -269,13 +269,13 @@ public async Task ExecuteAsync()
         httpClientFactory,
         serializerService,
         passwordTokenProvider);
-    
+
     //Get Customer Profile
     var myProfile = await meClient.WithApi().WithProjectKey("project-key")
         .Me()
         .Get()
         .ExecuteAsync();
-    
+
     //Get Customer Orders
     var myOrders = await
         meClient.WithApi()
@@ -286,8 +286,8 @@ public async Task ExecuteAsync()
             .ExecuteAsync();
 }
 ```
-If you are going to create the client using the ClientFactory, Don't forget to call 
-SetupClient extension method [here](https://github.com/commercetools/commercetools-dotnet-core-sdk-v2/blob/master/commercetools.Sdk/commercetools.Base.Client/DependencyInjectionSetup.cs#L92) while building 
+If you are going to create the client using the ClientFactory, Don't forget to call
+SetupClient extension method [here](https://github.com/commercetools/commercetools-dotnet-core-sdk-v2/blob/master/commercetools.Sdk/commercetools.Base.Client/DependencyInjectionSetup.cs#L92) while building
 the services container to attach the Default Handlers like ErrorHandler and LoggerHandler to the Client like below:
 ```c#
 services.SetupClient(

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains the .NET SDKs generated from the Composable Commerce AP
 | HTTP API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.Api?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.Api)|
 | Import API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.ImportApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.ImportApi)|
 | ML API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.MLApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.MLApi)|
-| History API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.HistoryApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)|
+| Change History API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.HistoryApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.HistoryApi)|
 
 ## Example and Training material
 Feel free to explore these examples using this SDK for calling Composable Commerce, and Import API.

--- a/commercetools.Sdk/commercetools.Base.Abstractions/Client/IClient.cs
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/Client/IClient.cs
@@ -5,7 +5,7 @@ using commercetools.Base.Serialization;
 namespace commercetools.Base.Client
 {
     /// <summary>
-    /// This interface defines the way to communicate with commercetools API.
+    /// This interface defines the way to communicate with Composable Commerce API.
     /// </summary>
     public interface IClient
     {

--- a/commercetools.Sdk/commercetools.Base.Abstractions/Client/IClient.cs
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/Client/IClient.cs
@@ -5,7 +5,7 @@ using commercetools.Base.Serialization;
 namespace commercetools.Base.Client
 {
     /// <summary>
-    /// This interface defines the way to communicate with Composable Commerce API.
+    /// This interface defines the way to communicate with the Composable Commerce HTTP API.
     /// </summary>
     public interface IClient
     {

--- a/commercetools.Sdk/commercetools.Base.Abstractions/commercetools.Base.Abstractions.csproj
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/commercetools.Base.Abstractions.csproj
@@ -5,7 +5,7 @@
         <RootNamespace>commercetools.Base</RootNamespace>
         <Version>0.1.0</Version>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Base.Client/commercetools.Base.Client.csproj
+++ b/commercetools.Sdk/commercetools.Base.Client/commercetools.Base.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Version>0.1.0</Version>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-    <Description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+    <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
     <Copyright>Copyright commercetools 2021</Copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Base.Registration/commercetools.Base.Registration.csproj
+++ b/commercetools.Sdk/commercetools.Base.Registration/commercetools.Base.Registration.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Version>0.1.0</Version>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-    <Description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+    <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
     <Copyright>Copyright commercetools 2021</Copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Base.Serialization/commercetools.Base.Serialization.csproj
+++ b/commercetools.Sdk/commercetools.Base.Serialization/commercetools.Base.Serialization.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Version>0.1.0</Version>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-    <Description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+    <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
     <Copyright>Copyright commercetools 2021</Copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Sdk.Api/commercetools.Sdk.Api.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.Api/commercetools.Sdk.Api.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Version>0.1.0</Version>
     <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-    <Description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+    <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
     <Copyright>Copyright commercetools 2021</Copyright>
     <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Sdk.HistoryApi/commercetools.Sdk.HistoryApi.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.HistoryApi/commercetools.Sdk.HistoryApi.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Sdk.ImportApi/commercetools.Sdk.ImportApi.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.ImportApi/commercetools.Sdk.ImportApi.csproj
@@ -3,14 +3,14 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>
         <PackageTags>commercetools;dotnet-core;sdk</PackageTags>
         <Version>0.1.0</Version>
     </PropertyGroup>
-    
+
     <ItemGroup>
       <ProjectReference Include="..\commercetools.Base.Abstractions\commercetools.Base.Abstractions.csproj" />
       <ProjectReference Include="..\commercetools.Base.Client\commercetools.Base.Client.csproj" />

--- a/commercetools.Sdk/commercetools.Sdk.MLApi/commercetools.Sdk.MLApi.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.MLApi/commercetools.Sdk.MLApi.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The commercetools SDK allows developers to work effectively with the commercetools platform in their .NET applications by providing typesafe access to the commercetools HTTP API.</Description>
+        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>


### PR DESCRIPTION
# Description
This PR follows the rebranding initiative by the Marketing and Docs team to change commercetools to Composable Commerce.

https://github.com/commercetools/clients-team-internal/issues/87

NB: This PR does not update the tests and generated files, as this is out of scope.