### PR TITLE
Update SUNRISE data link in ME Endpoint Checkout App

### DIFF
--- a/commercetools.Sdk/Examples/commercetools.Api.CheckoutApp/README.md
+++ b/commercetools.Sdk/Examples/commercetools.Api.CheckoutApp/README.md
@@ -7,7 +7,7 @@ This example application demonstrates how the ME endpoints can be used with the 
 - A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/getting-started/create-api-client#create-an-api-client).
   - Your API Client must have the following scopes: `view_published_products`, `view_categories`, `manage_my_profile`, `manage_my_shopping_lists`, `manage_my_payments`, `manage_my_orders`
 - Your Project must have existing Products containing Variants with SKUs, and at least one Customer.
-  - If your Project is currently empty, you can install the [SUNRISE sample data](https://docs.commercetools.com/sdk/sunrise-data).
+  - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
 
 ## Installation
 


### PR DESCRIPTION
We will be removing the SUNRISE data page from the docs soon, so I'm changing the link to point to the GitHub repo.

