### PR TITLE
Avoid using strings when deserializing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,10 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        container:
-          - BuiltIn
+        UseStreamClient:
+          - true
     env:
-      CTP_Container: ${{ matrix.container }}
+      CTP_UseStreamClient: ${{ matrix.UseStreamClient }}
       CTP_Client__ClientId: ${{ secrets.CTP_CLIENT_ID }}
       CTP_Client__ClientSecret: ${{ secrets.CTP_CLIENT_SECRET }}
       CTP_Client__ProjectKey: ${{ secrets.CTP_PROJECT_KEY }}

--- a/commercetools.Sdk/IntegrationTests/commercetools.Api.IntegrationTests/PollyTest.cs
+++ b/commercetools.Sdk/IntegrationTests/commercetools.Api.IntegrationTests/PollyTest.cs
@@ -67,7 +67,7 @@ namespace commercetools.Api.IntegrationTests
                     builder.PrimaryHandler = new HttpClientHandler
                     {
                         AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip,
-                        Proxy = new WebProxy("http://localhost:8080")
+                        Proxy = new WebProxy("http://localhost:18080")
                     };
                 });
 

--- a/commercetools.Sdk/IntegrationTests/commercetools.Api.IntegrationTests/ServiceProviderFixture.cs
+++ b/commercetools.Sdk/IntegrationTests/commercetools.Api.IntegrationTests/ServiceProviderFixture.cs
@@ -1,4 +1,5 @@
-﻿using commercetools.Sdk.Api.Models.Errors;
+﻿using System;
+using commercetools.Sdk.Api.Models.Errors;
 using commercetools.Base.Client;
 using commercetools.Sdk.Api;
 using commercetools.Sdk.Api.Serialization;
@@ -25,7 +26,8 @@ namespace commercetools.Api.IntegrationTests
                 AddEnvironmentVariables("CTP_").
                 Build();
 
-            services.UseCommercetoolsApi(configuration, "Client");
+            var useStreamClient = bool.Parse(configuration.GetValue("UseStreamClient", "false"));
+            services.UseCommercetoolsApi(configuration, "Client", options: new ClientOptions { ReadResponseAsStream = useStreamClient });
             services.AddLogging(c => c.AddProvider(new InMemoryLoggerProvider()));
             services.SetupClient(
                 "MeClient",

--- a/commercetools.Sdk/commercetools.Base.Abstractions/Serialization/ISerializerService.cs
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/Serialization/ISerializerService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 
 namespace commercetools.Base.Serialization
 {

--- a/commercetools.Sdk/commercetools.Base.Abstractions/Serialization/ISerializerService.cs
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/Serialization/ISerializerService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace commercetools.Base.Serialization
 {
@@ -7,6 +8,7 @@ namespace commercetools.Base.Serialization
         string Serialize<T>(T input);
 
         T Deserialize<T>(string input);
+        T Deserialize<T>(Stream inputStream);
 
         object Deserialize(Type returnType, string input);
     }

--- a/commercetools.Sdk/commercetools.Base.Abstractions/Serialization/ISerializerService.cs
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/Serialization/ISerializerService.cs
@@ -8,8 +8,6 @@ namespace commercetools.Base.Serialization
         string Serialize<T>(T input);
 
         T Deserialize<T>(string input);
-        T Deserialize<T>(Stream inputStream);
-
         object Deserialize(Type returnType, string input);
     }
 }

--- a/commercetools.Sdk/commercetools.Base.Abstractions/Serialization/IStreamSerializerService.cs
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/Serialization/IStreamSerializerService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.IO;
+
+namespace commercetools.Base.Serialization
+{
+    public interface IStreamSerializerService : ISerializerService
+    {
+        T Deserialize<T>(Stream inputStream);
+    }
+}

--- a/commercetools.Sdk/commercetools.Base.Client/ApiMethod.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/ApiMethod.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 
 namespace commercetools.Base.Client
@@ -73,6 +74,7 @@ namespace commercetools.Base.Client
         {
             var requestPath = new Uri(RequestUrl + ToQueryString(QueryParams), UriKind.Relative);
             var request = new HttpRequestMessage();
+            request.Version = HttpVersion.Version20;
             request.Method = this.Method;
             request.RequestUri = requestPath;
             request.AddHeaders(Headers);

--- a/commercetools.Sdk/commercetools.Base.Client/ClientOptions.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/ClientOptions.cs
@@ -6,5 +6,7 @@ namespace commercetools.Base.Client
     {
         public DecompressionMethods DecompressionMethods { get; set; } =
             DecompressionMethods.Deflate | DecompressionMethods.GZip;
+
+        public bool ReadResponseAsStream { get; set; } = false;
     }
 }

--- a/commercetools.Sdk/commercetools.Base.Client/DependencyInjectionSetup.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/DependencyInjectionSetup.cs
@@ -27,6 +27,7 @@ namespace commercetools.Base.Client
             Func<string, IConfiguration, IServiceProvider, ITokenProvider> tokenProviderSupplier,
             ClientOptions options = null)
         {
+            options ??= new ClientOptions();
             if (clients.Count() == 1)
             {
                 return services.UseSingleClient(configuration, clients.First(), serializerFactory, errorResponseTypeMapper, tokenProviderSupplier, options);
@@ -40,7 +41,7 @@ namespace commercetools.Base.Client
             Func<IServiceProvider, ISerializerService> serializerFactory,
             Func<HttpResponseMessage, Type> errorResponseTypeMapper,
             Func<string, IConfiguration, IServiceProvider, ITokenProvider> tokenProviderSupplier,
-            ClientOptions options = null)
+            ClientOptions options)
         {
             var builders = new ConcurrentDictionary<string, IHttpClientBuilder>();
 
@@ -56,7 +57,8 @@ namespace commercetools.Base.Client
                     var client = ClientFactory.Create(clientName, clientConfiguration,
                         serviceProvider.GetService<IHttpClientFactory>(),
                         serializerFactory(serviceProvider),
-                        tokenProviderSupplier(clientName, configuration, serviceProvider));
+                        tokenProviderSupplier(clientName, configuration, serviceProvider),
+                        options.ReadResponseAsStream);
                     client.Name = clientName;
                     return client;
                 });
@@ -70,7 +72,7 @@ namespace commercetools.Base.Client
             Func<IServiceProvider, ISerializerService> serializerFactory,
             Func<HttpResponseMessage, Type> errorResponseTypeMapper,
             Func<string, IConfiguration, IServiceProvider, ITokenProvider> tokenProviderSupplier,
-            ClientOptions options = null)
+            ClientOptions options)
         {
             IClientConfiguration clientConfiguration = configuration.GetSection(clientName).Get<ClientConfiguration>();
             Validator.ValidateObject(clientConfiguration, new ValidationContext(clientConfiguration), true);
@@ -80,7 +82,8 @@ namespace commercetools.Base.Client
                 var client = ClientFactory.Create(clientName, clientConfiguration,
                     serviceProvider.GetService<IHttpClientFactory>(),
                     serializerFactory(serviceProvider),
-                    tokenProviderSupplier(clientName, configuration, serviceProvider));
+                    tokenProviderSupplier(clientName, configuration, serviceProvider),
+                    options.ReadResponseAsStream);
                 client.Name = clientName;
                 return client;
             });

--- a/commercetools.Sdk/commercetools.Base.Client/ITokenSerializerService.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/ITokenSerializerService.cs
@@ -2,7 +2,7 @@
 
 namespace commercetools.Base.Client
 {
-    public interface ITokenSerializerService : ISerializerService
+    public interface ITokenSerializerService : IStreamSerializerService
     {
     }
 }

--- a/commercetools.Sdk/commercetools.Base.Client/Middlewares/HttpMiddleware.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/Middlewares/HttpMiddleware.cs
@@ -16,7 +16,7 @@ namespace commercetools.Base.Client.Middlewares
 
         protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            return await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/commercetools.Sdk/commercetools.Base.Client/Middlewares/StreamHttpMiddleware.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/Middlewares/StreamHttpMiddleware.cs
@@ -4,11 +4,11 @@ using System.Threading.Tasks;
 
 namespace commercetools.Base.Client.Middlewares
 {
-    public class HttpMiddleware : DelegatingMiddleware
+    public class StreamHttpMiddleware : DelegatingMiddleware
     {
         private readonly HttpClient client;
 
-        public HttpMiddleware(HttpClient client)
+        public StreamHttpMiddleware(HttpClient client)
         {
             this.client = client;
         }
@@ -16,7 +16,7 @@ namespace commercetools.Base.Client.Middlewares
 
         protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            return await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/commercetools.Sdk/commercetools.Base.Client/StreamCtpClient.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/StreamCtpClient.cs
@@ -6,29 +6,30 @@ using commercetools.Base.Serialization;
 
 namespace commercetools.Base.Client
 {
-    public class CtpClient : IClient
+    public class StreamCtpClient : IClient
     {
-        public CtpClient(
+        public StreamCtpClient(
             Middleware middlewareStack,
-            ISerializerService serializerService) : this(middlewareStack, serializerService, DefaultClientNames.Api)
+            IStreamSerializerService serializerService) : this(middlewareStack, serializerService, DefaultClientNames.Api)
         {
             this.MiddlewareStack = middlewareStack;
-            this.SerializerService = serializerService;
+            this._serializerService = serializerService;
         }
 
-        public CtpClient(
+        public StreamCtpClient(
             Middleware middlewareStack,
-            ISerializerService serializerService,
+            IStreamSerializerService serializerService,
             string name)
         {
             this.MiddlewareStack = middlewareStack;
-            this.SerializerService = serializerService;
+            this._serializerService = serializerService;
             this.Name = name;
         }
 
+        private readonly IStreamSerializerService _serializerService;
 
         public string Name { get; set; }
-        public ISerializerService SerializerService { get; }
+        public ISerializerService SerializerService => _serializerService;
         private Middleware MiddlewareStack { get; }
 
         public async Task<T> ExecuteAsync<T>(HttpRequestMessage requestMessage, CancellationToken cancellationToken = default)
@@ -45,9 +46,10 @@ namespace commercetools.Base.Client
 
         public async Task<IApiResponse<T>> SendAsync<T>(HttpRequestMessage requestMessage, CancellationToken cancellationToken = default)
         {
-            var result = await SendAsJsonAsync(requestMessage, cancellationToken);
-            var body = this.SerializerService.Deserialize<T>(result.Body);
-            return new ApiResponse<T>(result.StatusCode, result.ReasonPhrase, result.HttpHeaders, body);
+            using var result = await SendAsAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+            await using var contentStream = await result.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            var content = _serializerService.Deserialize<T>(contentStream);
+            return new ApiResponse<T>(result.StatusCode, result.ReasonPhrase, result.Headers, content);
         }
 
         public async Task<IApiResponse<string>> SendAsJsonAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken = default)

--- a/commercetools.Sdk/commercetools.Base.Client/TokenSerializerService.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/TokenSerializerService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Text.Json;
 
 namespace commercetools.Base.Client
@@ -18,6 +19,11 @@ namespace commercetools.Base.Client
         public T Deserialize<T>(string input)
         {
             return JsonSerializer.Deserialize<T>(input, jsonSerializerOptions);
+        }
+
+        public T Deserialize<T>(Stream inputStream)
+        {
+            return JsonSerializer.Deserialize<T>(inputStream, jsonSerializerOptions);
         }
 
         public object Deserialize(Type returnType, string input)

--- a/commercetools.Sdk/commercetools.Base.Serialization/BaseSerializerService.cs
+++ b/commercetools.Sdk/commercetools.Base.Serialization/BaseSerializerService.cs
@@ -1,12 +1,13 @@
 ﻿using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using commercetools.Base.Registration;
 using commercetools.Base.Serialization.JsonConverters;
 using Type = System.Type;
 
 namespace commercetools.Base.Serialization
 {
-    public class BaseSerializerService : ISerializerService
+    public class BaseSerializerService : IStreamSerializerService
     {
         protected readonly JsonSerializerOptions _serializerOptions;
 

--- a/commercetools.Sdk/commercetools.Base.Serialization/BaseSerializerService.cs
+++ b/commercetools.Sdk/commercetools.Base.Serialization/BaseSerializerService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.IO;
+using System.Text.Json;
 using commercetools.Base.Registration;
 using commercetools.Base.Serialization.JsonConverters;
 using Type = System.Type;
@@ -30,6 +31,11 @@ namespace commercetools.Base.Serialization
         public T Deserialize<T>(string input)
         {
             return JsonSerializer.Deserialize<T>(input, _serializerOptions);
+        }
+
+        public T Deserialize<T>(Stream inputStream)
+        {
+            return JsonSerializer.Deserialize<T>(inputStream, _serializerOptions);
         }
 
         public object Deserialize(Type returnType, string input)

--- a/commercetools.Sdk/commercetools.Sdk.Api/Serialization/IApiSerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Api/Serialization/IApiSerializerService.cs
@@ -2,7 +2,7 @@ using commercetools.Base.Serialization;
 
 namespace commercetools.Sdk.Api.Serialization
 {
-    public interface IApiSerializerService : ISerializerService
+    public interface IApiSerializerService : IStreamSerializerService
     {
 
     }

--- a/commercetools.Sdk/commercetools.Sdk.Api/Serialization/SerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Api/Serialization/SerializerService.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
 using commercetools.Sdk.Api.Models.Products;
 using commercetools.Sdk.Api.Models.Types;
@@ -28,7 +30,7 @@ namespace commercetools.Sdk.Api.Serialization
 
             public override string ConvertName(string name)
             {
-                return _fieldMapping.ContainsKey(name) ? _fieldMapping[name] : _policy.ConvertName(name);
+                return _fieldMapping.TryGetValue(name, out string mappedName) ? mappedName : _policy.ConvertName(name);
             }
         }
 
@@ -60,6 +62,11 @@ namespace commercetools.Sdk.Api.Serialization
         public T Deserialize<T>(string input)
         {
             return JsonSerializer.Deserialize<T>(input, _serializerOptions);
+        }
+
+        public T Deserialize<T>(Stream inputStream)
+        {
+            return JsonSerializer.Deserialize<T>(inputStream, _serializerOptions);
         }
 
         public object Deserialize(Type returnType, string input)

--- a/commercetools.Sdk/commercetools.Sdk.Api/Serialization/SerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Api/Serialization/SerializerService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using commercetools.Sdk.Api.Models.Products;

--- a/commercetools.Sdk/commercetools.Sdk.GraphQL.Api/GraphQLClientExtensions.cs
+++ b/commercetools.Sdk/commercetools.Sdk.GraphQL.Api/GraphQLClientExtensions.cs
@@ -24,7 +24,7 @@ public static class GraphQlClientExtensions
     }
 }
 
-internal class ClientHandler : IHttpHandler
+internal sealed class ClientHandler : IHttpHandler
 {
     private readonly IClient _client;
     private readonly Uri _graphQlUri;

--- a/commercetools.Sdk/commercetools.Sdk.HistoryApi/Serialization/IHistorySerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.HistoryApi/Serialization/IHistorySerializerService.cs
@@ -2,7 +2,7 @@ using commercetools.Base.Serialization;
 
 namespace commercetools.Sdk.HistoryApi.Serialization
 {
-    public interface IHistorySerializerService : ISerializerService
+    public interface IHistorySerializerService : IStreamSerializerService
     {
 
     }

--- a/commercetools.Sdk/commercetools.Sdk.HistoryApi/Serialization/SerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.HistoryApi/Serialization/SerializerService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text.Json;
 using commercetools.Base.Serialization.JsonConverters;
 using Type = System.Type;
@@ -27,6 +28,11 @@ namespace commercetools.Sdk.HistoryApi.Serialization
         public T Deserialize<T>(string input)
         {
             return JsonSerializer.Deserialize<T>(input, _serializerOptions);
+        }
+
+        public T Deserialize<T>(Stream inputStream)
+        {
+            return JsonSerializer.Deserialize<T>(inputStream, _serializerOptions);
         }
 
         public object Deserialize(Type returnType, string input)

--- a/commercetools.Sdk/commercetools.Sdk.ImportApi/Serialization/IImportSerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.ImportApi/Serialization/IImportSerializerService.cs
@@ -2,7 +2,7 @@ using commercetools.Base.Serialization;
 
 namespace commercetools.Sdk.ImportApi.Serialization
 {
-    public interface IImportSerializerService : ISerializerService
+    public interface IImportSerializerService : IStreamSerializerService
     {
 
     }

--- a/commercetools.Sdk/commercetools.Sdk.ImportApi/Serialization/SerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.ImportApi/Serialization/SerializerService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.IO;
+using System.Text.Json;
 using commercetools.Base.Serialization.JsonConverters;
 using Type = System.Type;
 
@@ -27,6 +28,11 @@ namespace commercetools.Sdk.ImportApi.Serialization
         public T Deserialize<T>(string input)
         {
             return JsonSerializer.Deserialize<T>(input, _serializerOptions);
+        }
+
+        public T Deserialize<T>(Stream inputStream)
+        {
+            return JsonSerializer.Deserialize<T>(inputStream, _serializerOptions);
         }
 
         public object Deserialize(Type returnType, string input)

--- a/commercetools.Sdk/commercetools.Sdk.MLApi/Serialization/IMLSerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.MLApi/Serialization/IMLSerializerService.cs
@@ -2,7 +2,7 @@ using commercetools.Base.Serialization;
 
 namespace commercetools.Sdk.MLApi.Serialization
 {
-    public interface IMLSerializerService : ISerializerService
+    public interface IMLSerializerService : IStreamSerializerService
     {
 
     }

--- a/commercetools.Sdk/commercetools.Sdk.MLApi/Serialization/SerializerService.cs
+++ b/commercetools.Sdk/commercetools.Sdk.MLApi/Serialization/SerializerService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text.Json;
 using commercetools.Base.Serialization.JsonConverters;
 using Type = System.Type;
@@ -27,6 +28,11 @@ namespace commercetools.Sdk.MLApi.Serialization
         public T Deserialize<T>(string input)
         {
             return JsonSerializer.Deserialize<T>(input, _serializerOptions);
+        }
+
+        public T Deserialize<T>(Stream inputStream)
+        {
+            return JsonSerializer.Deserialize<T>(inputStream, _serializerOptions);
         }
 
         public object Deserialize(Type returnType, string input)


### PR DESCRIPTION
Also:
- avoid waiting for the entire response before deserializing
- avoid double lookup in dictionary
- Use HTTP2


In regards to unit tests, should stream deserializing be tested or can we assume it works if strings are tested?
If so, in the existing methods? Or in new separate methods?

- [ ] Changeset added

### Features
Use streams for deserialization, instead of allocating potentially huge strings.
Deserialization can also start before the entire response has returned when using a stream

### Fixes
Performance, lowers memory usage

### Breaking changes
None
