### PR TITLE
Make the client using streams the default. Using strings is not sustainable

### DIFF
--- a/commercetools.Sdk/IntegrationTests/commercetools.Api.IntegrationTests/ServiceProviderFixture.cs
+++ b/commercetools.Sdk/IntegrationTests/commercetools.Api.IntegrationTests/ServiceProviderFixture.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace commercetools.Api.IntegrationTests
 {
-    public class ServiceProviderFixture
+    public sealed class ServiceProviderFixture
     {
         private readonly ServiceProvider serviceProvider;
         private readonly IConfiguration configuration;
@@ -26,7 +26,7 @@ namespace commercetools.Api.IntegrationTests
                 AddEnvironmentVariables("CTP_").
                 Build();
 
-            var useStreamClient = Enum.Parse<ClientType>(configuration.GetValue("ClientType", "String")) == ClientType.Stream;
+            var useStreamClient = Enum.Parse<ClientType>(configuration.GetValue("ClientType", "String")) != ClientType.String;
             services.UseCommercetoolsApi(configuration, "Client", options: new ClientOptions { ReadResponseAsStream = useStreamClient });
             services.AddLogging(c => c.AddProvider(new InMemoryLoggerProvider()));
             services.SetupClient(

--- a/commercetools.Sdk/IntegrationTests/commercetools.GraphQL.Api.IntegrationTests/ServiceProviderFixture.cs
+++ b/commercetools.Sdk/IntegrationTests/commercetools.GraphQL.Api.IntegrationTests/ServiceProviderFixture.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace commercetools.GraphQL.Api.IntegrationTests
 {
-    public class ServiceProviderFixture
+    public sealed class ServiceProviderFixture
     {
         private readonly ServiceProvider serviceProvider;
         private readonly IConfiguration configuration;
@@ -24,7 +24,7 @@ namespace commercetools.GraphQL.Api.IntegrationTests
                 AddUserSecrets<ServiceProviderFixture>().
                 AddEnvironmentVariables("CTP_").
                 Build();
-            var useStreamClient = Enum.Parse<ClientType>(configuration.GetValue("ClientType", "String")) == ClientType.Stream;
+            var useStreamClient = Enum.Parse<ClientType>(configuration.GetValue("ClientType", "String")) != ClientType.String;
 
             services.UseCommercetoolsApi(configuration, "Client", options: new ClientOptions { ReadResponseAsStream = useStreamClient });
             services.AddLogging(c => c.AddProvider(new InMemoryLoggerProvider()));

--- a/commercetools.Sdk/IntegrationTests/commercetools.ImportApi.IntegrationTests/ServiceProviderFixture.cs
+++ b/commercetools.Sdk/IntegrationTests/commercetools.ImportApi.IntegrationTests/ServiceProviderFixture.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace commercetools.ImportApi.IntegrationTests
 {
-    public class ServiceProviderFixture
+    public sealed class ServiceProviderFixture
     {
         private readonly ServiceProvider serviceProvider;
         private readonly IConfiguration configuration;
@@ -22,7 +22,7 @@ namespace commercetools.ImportApi.IntegrationTests
                 AddEnvironmentVariables("CTP_").
                 Build();
 
-            var useStreamClient = Enum.Parse<ClientType>(configuration.GetValue("ClientType", "String")) == ClientType.Stream;
+            var useStreamClient = Enum.Parse<ClientType>(configuration.GetValue("ClientType", "String")) != ClientType.String;
             services.UseCommercetoolsImportApi(configuration, "ImportClient", options: new ClientOptions { ReadResponseAsStream = useStreamClient });
             this.serviceProvider = services.BuildServiceProvider();
 

--- a/commercetools.Sdk/commercetools.Base.Client/ClientOptions.cs
+++ b/commercetools.Sdk/commercetools.Base.Client/ClientOptions.cs
@@ -8,7 +8,7 @@ namespace commercetools.Base.Client
         public DecompressionMethods DecompressionMethods { get; set; } =
             DecompressionMethods.Deflate | DecompressionMethods.GZip;
 
-        public bool ReadResponseAsStream { get; set; } = false;
+        public bool ReadResponseAsStream { get; set; } = true;
 
         public Version UseHttpVersion { get; set; } = null;
     }


### PR DESCRIPTION
### Features
Always use streams to deserialize by setting the default to true.
The streaming client was introduced in https://github.com/commercetools/commercetools-dotnet-core-sdk-v2/pull/266

By only changing this setting, the CPU graph changed like this: 
![Screenshot 2024-10-03 134328](https://github.com/user-attachments/assets/4d739fbe-3c0f-46f5-92f7-bccd43d0d91b)
and the API performed much better

### Fixes
- Reduces the CO₂ created by commercetools
- Improves the experience of commercetools

![HOW DARE YOU](https://media.giphy.com/media/SuIDKboVhHgtLPG6zm/giphy.gif)

### Breaking changes
None

