### PR TITLE
Remove Composable Commerce branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Composable Commerce .NET SDK
+# commercetools .NET SDK
 
 ## Introduction
 
-This repository contains the .NET SDKs generated from the Composable Commerce API reference. 
+This repository contains the .NET SDKs generated from the commercetools API reference. 
 
 ## Packages
 
@@ -14,7 +14,7 @@ This repository contains the .NET SDKs generated from the Composable Commerce AP
 | Checkout API | [![NuGet Version and Downloads count](https://buildstats.info/nuget/commercetools.Sdk.CheckoutApi?includePreReleases=true)](https://www.nuget.org/packages/commercetools.Sdk.CheckoutApi)|
 
 ## Example and Training material
-Feel free to explore these examples using this SDK for calling the Composable Commerce HTTP API, and Import API.
+Feel free to explore these examples using this SDK for calling the commercetools HTTP API, and Import API.
 [.NET Core SDK Training for V2 SDK](https://github.com/commercetools/commercetools-dotnet-sdk-training/tree/Training-SDKV2)
 
 ## Installation
@@ -31,14 +31,14 @@ Feel free to explore these examples using this SDK for calling the Composable Co
 
 The SDK consists of the following projects:
 * `commercetools.Base.Abstractions`: Contains common classes and interfaces that can be used in other SDK projects like IClient and ISerializerService.
-* `commercetools.Base.Client`: Contains `CtpClient` which communicate with Composable Commerce to execute requests, it contains also the classes related to the client like tokens, middleware, and handlers.
+* `commercetools.Base.Client`: Contains `CtpClient` which communicate with commercetools to execute requests. It contains also the classes related to the client like tokens, middleware, and handlers.
 * `commercetools.Base.Registration`: Helper classes for things like types retriever.
-* `commercetools.Base.Serialization`: Serialization and deserialization services for responses and requests to the HTTP API using System.Text.Json.
-* `commercetools.Sdk.Api`: Contains all generated models and request builders to communicate with [Composable Commerce HTTP API](https://docs.commercetools.com/api).
+* `commercetools.Base.Serialization`: Serialization and deserialization services for responses and requests to the [HTTP API](https://docs.commercetools.com/api) using System.Text.Json.
+* `commercetools.Sdk.Api`: Contains all generated models and request builders to communicate with the [HTTP API](https://docs.commercetools.com/api).
 * `commercetools.Sdk.ImportApi`: Contains all generated models and request builders to communicate with the [Import API](https://docs.commercetools.com/api/import-export/overview).
 * `commercetools.Sdk.HistoryApi`: Contains all generated models and request builders to communicate with the [Change History API](https://docs.commercetools.com/api/history/change-history).
 * `commercetools.Sdk.CheckoutApi`: Contains all generated models and request builders to communicate with the [Checkout API](https://docs.commercetools.com/checkout/general-concepts).
-* `commercetools.Sdk.GraphQL.Api`: Contains a type safe GraphQL client to communicate with [Composable Commerce HTTP API](https://docs.commercetools.com/api).
+* `commercetools.Sdk.GraphQL.Api`: Contains a type safe GraphQL client to communicate with [GraphQL API](https://docs.commercetools.com/api/graphql).
 
 In addition, the SDK has the following directories:
 * `/IntegrationTests`: Integration tests for the SDK. A good way for anyone using the .NET SDK to understand it further.
@@ -75,7 +75,7 @@ At a high level, to make a basic call to the API, do the following:
 
  In the ConfigureServices method of Startup.cs add the following:
 
-* `Composable Commerce HTTP API`:
+* `HTTP API`:
 ```csharp
 services.UseCommercetoolsApi(this.configuration, "Client"); // replace with your instance of IConfiguration
 ```
@@ -106,7 +106,7 @@ The client configuration needs to be added to appsettings.json in order for the 
 
 ##### Getting instance of ApiRoot
 you can use the instance inside the injected client or use ApiFactory to create a new instance.
-* `Composable Commerce HTTP API`:
+* `HTTP API`:
 ```csharp
 var root1 = client.WithApi();
 var root2 = ApiFactory.Create(client);
@@ -128,7 +128,7 @@ The ProjectApiRoot is scoped to the projectKey in order to not have to provide t
 for building requests. You can use the instance inside the injected client or use ApiFactory
 to create a new instance.
 
-* `Composable Commerce HTTP API`:
+* `HTTP API`:
 ```csharp
 ProjectApiRoot root1 = client.WithProject(projectKey);
 ProjectApiRoot root2 = ApiFactory.Create(client, projectKey);

--- a/commercetools.Sdk/Examples/commercetools.Api.ApmExample/README.md
+++ b/commercetools.Sdk/Examples/commercetools.Api.ApmExample/README.md
@@ -4,7 +4,7 @@ This example application demonstrates how the ME endpoints can be used with the 
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
+- A commercetools Projectwith a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
   - Your API Client must have the following scopes: `view_published_products`, `view_categories`, `manage_my_profile`, `manage_my_shopping_lists`, `manage_my_payments`, `manage_my_orders`
 - Your Project must have existing Products containing Variants with SKUs, and at least one Customer.
   - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).

--- a/commercetools.Sdk/Examples/commercetools.Api.CheckoutApp/README.md
+++ b/commercetools.Sdk/Examples/commercetools.Api.CheckoutApp/README.md
@@ -4,7 +4,7 @@ This example application demonstrates how the ME endpoints can be used with the 
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
+- A commercetools Projectwith a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
   - Your API Client must have the following scopes: `view_published_products`, `view_categories`, `manage_my_profile`, `manage_my_shopping_lists`, `manage_my_payments`, `manage_my_orders`
 - Your Project must have existing Products containing Variants with SKUs, and at least one Customer.
   - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).

--- a/commercetools.Sdk/Examples/commercetools.Api.NewRelicExample/README.md
+++ b/commercetools.Sdk/Examples/commercetools.Api.NewRelicExample/README.md
@@ -4,7 +4,7 @@ This example application demonstrates how the ME endpoints can be used with the 
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
+- A commercetools Projectwith a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
   - Your API Client must have the following scopes: `view_published_products`, `view_categories`, `manage_my_profile`, `manage_my_shopping_lists`, `manage_my_payments`, `manage_my_orders`
 - Your Project must have existing Products containing Variants with SKUs, and at least one Customer.
   - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).

--- a/commercetools.Sdk/commercetools.Base.Abstractions/Client/IClient.cs
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/Client/IClient.cs
@@ -6,7 +6,7 @@ using commercetools.Base.Serialization;
 namespace commercetools.Base.Client
 {
     /// <summary>
-    /// This interface defines the way to communicate with the Composable Commerce HTTP API.
+    /// This interface defines the way to communicate with commercetools APIs.
     /// </summary>
     public interface IClient
     {

--- a/commercetools.Sdk/commercetools.Base.Abstractions/commercetools.Base.Abstractions.csproj
+++ b/commercetools.Sdk/commercetools.Base.Abstractions/commercetools.Base.Abstractions.csproj
@@ -5,7 +5,7 @@
         <RootNamespace>commercetools.Base</RootNamespace>
         <Version>0.1.0</Version>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Base.Client/commercetools.Base.Client.csproj
+++ b/commercetools.Sdk/commercetools.Base.Client/commercetools.Base.Client.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net6.0</TargetFrameworks>
         <Version>0.1.0</Version>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Base.Registration/commercetools.Base.Registration.csproj
+++ b/commercetools.Sdk/commercetools.Base.Registration/commercetools.Base.Registration.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net6.0</TargetFrameworks>
         <Version>0.1.0</Version>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Base.Serialization/commercetools.Base.Serialization.csproj
+++ b/commercetools.Sdk/commercetools.Base.Serialization/commercetools.Base.Serialization.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net6.0</TargetFrameworks>
         <Version>0.1.0</Version>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Sdk.Api/commercetools.Sdk.Api.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.Api/commercetools.Sdk.Api.csproj
@@ -3,7 +3,7 @@
         <TargetFrameworks>net6.0</TargetFrameworks>
         <Version>0.1.0</Version>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Sdk.CheckoutApi/commercetools.Sdk.CheckoutApi.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.CheckoutApi/commercetools.Sdk.CheckoutApi.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net6.0</TargetFrameworks>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Sdk.GraphQL.Api/commercetools.Sdk.GraphQL.Api.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.GraphQL.Api/commercetools.Sdk.GraphQL.Api.csproj
@@ -6,7 +6,7 @@
         <LangVersion>latestmajor</LangVersion>
         <Version>0.1.0</Version>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Sdk.HistoryApi/commercetools.Sdk.HistoryApi.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.HistoryApi/commercetools.Sdk.HistoryApi.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net6.0</TargetFrameworks>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/commercetools.Sdk/commercetools.Sdk.ImportApi/commercetools.Sdk.ImportApi.csproj
+++ b/commercetools.Sdk/commercetools.Sdk.ImportApi/commercetools.Sdk.ImportApi.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net6.0</TargetFrameworks>
         <RepositoryUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</RepositoryUrl>
-        <Description>The Composable Commerce SDK allows developers to work effectively by providing typesafe access to commercetools Composable Commerce in their .NET applications.</Description>
+        <Description>The commercetools SDK allows developers to work effectively by providing typesafe access to commercetools APIs in their .NET applications.</Description>
         <Copyright>Copyright commercetools 2021</Copyright>
         <PackageProjectUrl>https://github.com/commercetools/commercetools-dotnet-core-sdk-v2</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/commercetools/commercetools-dotnet-core-sdk-v2/master/ct-logo.png</PackageIconUrl>

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,7 +1,7 @@
 # Comparison between DotNet Core SDK V2 and V1
 ## Why I should use V2 SDK
 The SDK [V2](/) has some features which is not exists in [V1](https://github.com/commercetools/commercetools-dotnet-core-sdk) like:
-* V1 only supports the Composable Commerce HTTP API, but V2 has different packages to support the Import API, Machine Learning API, and the Change History API.
+* V1 only supports the commercetools HTTP API, but V2 has different packages to support the Import API and the Change History API.
 * V2 SDK supports ME endpoints.
 * V2 SDK is auto generated from RAML files like other SDKS which means less maintainability and it will be always up-to-date with backend new features.
 * V2 SDK is faster than V1 SDK as it’s using System.Text.Json in Serialization and Deserialisation
@@ -12,7 +12,6 @@ The SDK [V2](/) has some features which is not exists in [V1](https://github.com
 |------------------------|--------------------------------------------------------|-------------------------------------------------|
 | HTTP API   | ```dotnet add package commercetools.Sdk.Api```         | ```dotnet add package commercetools.Sdk.All```  |
 | Import API             | ```dotnet add package commercetools.Sdk.ImportApi```   |                                                 |
-| Machine Learning API                 | ```dotnet add package commercetools.Sdk.MLApi```       |                                                 |
 | Change History API            | ```dotnet add package commercetools.Sdk.HistoryApi```  |                                                 |
 
 ## Comparison of SDK Services Configuration
@@ -23,10 +22,9 @@ After packages installation, you have to configure services using Dependency Inj
 | HTTP API             | ```services.UseCommercetoolsApi(this.configuration, "Client");```               | ```services.UseCommercetools(```    |
 |                      |                                                                                 | ```this.configuration,"Client");``` |
 | Import API           | ```services.UseCommercetoolsImportApi(this.configuration, "ImportClient");```   |                                     |
-| Machine Learning API | ```services.UseCommercetoolsMLApi(this.configuration, "MLClient");```           |                                     |
 | Change History API   | ```services.UseCommercetoolsHistoryApi(this.configuration, "HistoryClient");``` |                                     |
 
-## Comparison of how to make requests to the Composable Commerce HTTP API
+## Comparison of how to make requests to the commercetools HTTP API
 ```csharp
     // Create CategoryDraft
     var categoryDraft = new CategoryDraft


### PR DESCRIPTION
This PR removes the "Composable Commerce" branding from docs, comments, and descriptions.